### PR TITLE
Add feature evaluation event schema

### DIFF
--- a/Schema/FeatureEvaluationEvent.v1.0.0.schema.json
+++ b/Schema/FeatureEvaluationEvent.v1.0.0.schema.json
@@ -30,7 +30,7 @@
       "type": "string",
       "title": "Assigned Variant",
       "description": "The assigned variant during the feature evaluation.",
-      "pattern": "^[^\n\r]*$"
+      "pattern":  "^(.*)$"
     },
     "VariantAssignmentReason": {
       "$id": "#/properties/VariantAssignmentReason",

--- a/Schema/FeatureEvaluationEvent.v1.0.0.schema.json
+++ b/Schema/FeatureEvaluationEvent.v1.0.0.schema.json
@@ -50,7 +50,7 @@
       "$id": "#/properties/TargetingId",
       "type": "string",
       "title": "Targeting Id",
-      "description": "The user id used for the feature evaluation.",
+      "description": "The targeting id used for the feature evaluation.",
       "pattern": "^(.*)$"
     }
   }

--- a/Schema/FeatureEvaluationEvent.v1.0.0.schema.json
+++ b/Schema/FeatureEvaluationEvent.v1.0.0.schema.json
@@ -30,7 +30,7 @@
       "type": "string",
       "title": "Assigned Variant",
       "description": "The assigned variant during the feature evaluation.",
-      "pattern": "^[^:\n\r%]*$"
+      "pattern": "^[^\n\r]*$"
     },
     "VariantAssignmentReason": {
       "$id": "#/properties/VariantAssignmentReason",

--- a/Schema/FeatureEvaluationEvent.v1.0.0.schema.json
+++ b/Schema/FeatureEvaluationEvent.v1.0.0.schema.json
@@ -30,7 +30,7 @@
       "type": "string",
       "title": "Assigned Variant",
       "description": "The assigned variant during the feature evaluation.",
-      "pattern": "^(.*)$"
+      "pattern": "^[^:\n\r%]*$"
     },
     "VariantAssignmentReason": {
       "$id": "#/properties/VariantAssignmentReason",

--- a/Schema/FeatureEvaluationEvent.v1.0.0.schema.json
+++ b/Schema/FeatureEvaluationEvent.v1.0.0.schema.json
@@ -1,0 +1,58 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://azconfig.io/schemas/FeatureManagement/v1.0.0/FeatureEvaluationEvent.json",
+  "type": "object",
+  "title": "A Feature Evaluation Event",
+  "required": [
+    "FeatureName",
+    "Enabled",
+    "Variant",
+    "VariantAssignmentReason",
+    "TargetingId"
+  ],
+  "properties": {
+    "FeatureName": {
+      "$id": "#/properties/FeatureName",
+      "type": "string",
+      "title": "Feature Name",
+      "description": "The name of the feature flag being evaluated.",
+      "pattern": "^[^:%]*$"
+    },
+    "Enabled": {
+      "$id": "#/properties/Enabled",
+      "type": "boolean",
+      "title": "Feature Enabled",
+      "description": "Whether the feature flag is evaluated as enabled."
+    },
+    "Variant": {
+      "$id": "#/properties/Variant",
+      "type": "string",
+      "title": "Assigned Variant",
+      "description": "The assigned variant during the feature evaluation.",
+      "pattern": "^(.*)$"
+    },
+    "VariantAssignmentReason": {
+      "$id": "#/properties/VariantAssignmentReason",
+      "type": "string",
+      "title": "Variant Assignment Reason",
+      "description": "The reason why the variant is assigned during the feature evaluation.",
+      "enum": [
+        "None",
+        "DefaultWhenDisabled",
+        "DefaultWhenEnabled",
+        "User",
+        "Group",
+        "Percentile"
+      ]
+    },
+    "TargetingId": {
+      "$id": "#/properties/TargetingId",
+      "type": "string",
+      "title": "Targeting Id",
+      "description": "The user id used for the feature evaluation.",
+      "pattern": "^(.*)$"
+    }
+  }
+}
+    

--- a/Schema/FeatureEvaluationEvent.v1.0.0.schema.json
+++ b/Schema/FeatureEvaluationEvent.v1.0.0.schema.json
@@ -17,7 +17,7 @@
       "type": "string",
       "title": "Feature Name",
       "description": "The name of the feature flag being evaluated.",
-      "pattern": "^[^:%]*$"
+      "pattern": "^[^:\n\r%]*$"
     },
     "Enabled": {
       "$id": "#/properties/Enabled",

--- a/Schema/FeatureFlag.v2.0.0.schema.json
+++ b/Schema/FeatureFlag.v2.0.0.schema.json
@@ -16,7 +16,7 @@
       "examples": [
         "fancy-background"
       ],
-      "pattern": "^[^:%]*$"
+      "pattern": "^[^:\n\r%]*$"
     },
     "description": {
       "$id": "#/properties/description",
@@ -144,7 +144,7 @@
                   "type": "string",
                   "title": "Variant Name",
                   "description": "The name used to refer to a feature variant.",
-                  "pattern": "^(.*)$"
+                  "pattern": "^[^:\n\r%]*$"
               },
               "configuration_value": {
                   "$id": "#/properties/variants/items/properties/configuration_value",
@@ -181,7 +181,7 @@
               "title": "Default Variant Allocation When Disabled",
               "description": "Specifies which variant should be used when the feature is considered disabled.",
               "default": "",
-              "pattern": "^(.*)$"
+              "pattern": "^[^:\n\r%]*$"
           },
           "default_when_enabled": {
               "$id": "#/properties/allocation/properties/default_when_enabled",
@@ -189,7 +189,7 @@
               "title": "Default Variant Allocation When Enabled",
               "description": "Specifies which variant should be used when the feature is considered enabled and no other allocation rules are applicable.",
               "default": "",
-              "pattern": "^(.*)$"
+              "pattern": "^[^:\n\r%]*$"
           },
           "user": {
               "$id": "#/properties/allocation/properties/user",
@@ -210,7 +210,7 @@
                           "type": "string",
                           "title": "User Allocation Variant",
                           "description": "The name of the variant to use if the user allocation matches the current user.",
-                          "pattern": "^(.*)$"
+                          "pattern": "^[^:\n\r%]*$"
                       },
                       "users": {
                           "$id": "#/properties/allocation/properties/user/items/properties/users",
@@ -243,7 +243,7 @@
                           "type": "string",
                           "title": "Group Allocation Variant",
                           "description": "The name of the variant to use if the group allocation matches a group the current user is in.",
-                          "pattern": "^(.*)$"
+                          "pattern": "^[^:\n\r%]*$"
                       },
                       "groups": {
                           "$id": "#/properties/allocation/properties/group/items/properties/groups",
@@ -277,7 +277,7 @@
                           "type": "string",
                           "title": "Percentile Allocation Variant",
                           "description": "The name of the variant to use if the calculated percentile for the current user falls in the provided range.",
-                          "pattern": "^(.*)$"
+                          "pattern": "^[^:\n\r%]*$"
                       },
                       "from": {
                           "$id": "#/properties/allocation/properties/percentile/items/properties/from",

--- a/Schema/FeatureFlag.v2.0.0.schema.json
+++ b/Schema/FeatureFlag.v2.0.0.schema.json
@@ -144,7 +144,7 @@
                   "type": "string",
                   "title": "Variant Name",
                   "description": "The name used to refer to a feature variant.",
-                  "pattern": "^[^:\n\r%]*$"
+                  "pattern": "^[^\n\r]*$"
               },
               "configuration_value": {
                   "$id": "#/properties/variants/items/properties/configuration_value",
@@ -181,7 +181,7 @@
               "title": "Default Variant Allocation When Disabled",
               "description": "Specifies which variant should be used when the feature is considered disabled.",
               "default": "",
-              "pattern": "^[^:\n\r%]*$"
+              "pattern": "^[^\n\r]*$"
           },
           "default_when_enabled": {
               "$id": "#/properties/allocation/properties/default_when_enabled",
@@ -189,7 +189,7 @@
               "title": "Default Variant Allocation When Enabled",
               "description": "Specifies which variant should be used when the feature is considered enabled and no other allocation rules are applicable.",
               "default": "",
-              "pattern": "^[^:\n\r%]*$"
+              "pattern": "^[^\n\r]*$"
           },
           "user": {
               "$id": "#/properties/allocation/properties/user",
@@ -210,7 +210,7 @@
                           "type": "string",
                           "title": "User Allocation Variant",
                           "description": "The name of the variant to use if the user allocation matches the current user.",
-                          "pattern": "^[^:\n\r%]*$"
+                          "pattern": "^[^\n\r]*$"
                       },
                       "users": {
                           "$id": "#/properties/allocation/properties/user/items/properties/users",
@@ -243,7 +243,7 @@
                           "type": "string",
                           "title": "Group Allocation Variant",
                           "description": "The name of the variant to use if the group allocation matches a group the current user is in.",
-                          "pattern": "^[^:\n\r%]*$"
+                          "pattern": "^[^\n\r]*$"
                       },
                       "groups": {
                           "$id": "#/properties/allocation/properties/group/items/properties/groups",
@@ -277,7 +277,7 @@
                           "type": "string",
                           "title": "Percentile Allocation Variant",
                           "description": "The name of the variant to use if the calculated percentile for the current user falls in the provided range.",
-                          "pattern": "^[^:\n\r%]*$"
+                          "pattern": "^[^\n\r]*$"
                       },
                       "from": {
                           "$id": "#/properties/allocation/properties/percentile/items/properties/from",

--- a/Schema/FeatureFlag.v2.0.0.schema.json
+++ b/Schema/FeatureFlag.v2.0.0.schema.json
@@ -16,7 +16,7 @@
       "examples": [
         "fancy-background"
       ],
-      "pattern": "^(.*)$"
+      "pattern": "^[^:\n\r%]*$"
     },
     "description": {
       "$id": "#/properties/description",

--- a/Schema/FeatureFlag.v2.0.0.schema.json
+++ b/Schema/FeatureFlag.v2.0.0.schema.json
@@ -16,7 +16,7 @@
       "examples": [
         "fancy-background"
       ],
-      "pattern": "^[^:\n\r%]*$"
+      "pattern": "^(.*)$"
     },
     "description": {
       "$id": "#/properties/description",
@@ -144,7 +144,7 @@
                   "type": "string",
                   "title": "Variant Name",
                   "description": "The name used to refer to a feature variant.",
-                  "pattern": "^[^\n\r]*$"
+                  "pattern": "^(.*)$"
               },
               "configuration_value": {
                   "$id": "#/properties/variants/items/properties/configuration_value",
@@ -181,7 +181,7 @@
               "title": "Default Variant Allocation When Disabled",
               "description": "Specifies which variant should be used when the feature is considered disabled.",
               "default": "",
-              "pattern": "^[^\n\r]*$"
+              "pattern": "^(.*)$"
           },
           "default_when_enabled": {
               "$id": "#/properties/allocation/properties/default_when_enabled",
@@ -189,7 +189,7 @@
               "title": "Default Variant Allocation When Enabled",
               "description": "Specifies which variant should be used when the feature is considered enabled and no other allocation rules are applicable.",
               "default": "",
-              "pattern": "^[^\n\r]*$"
+              "pattern": "^(.*)$"
           },
           "user": {
               "$id": "#/properties/allocation/properties/user",
@@ -210,7 +210,7 @@
                           "type": "string",
                           "title": "User Allocation Variant",
                           "description": "The name of the variant to use if the user allocation matches the current user.",
-                          "pattern": "^[^\n\r]*$"
+                          "pattern": "^(.*)$"
                       },
                       "users": {
                           "$id": "#/properties/allocation/properties/user/items/properties/users",
@@ -243,7 +243,7 @@
                           "type": "string",
                           "title": "Group Allocation Variant",
                           "description": "The name of the variant to use if the group allocation matches a group the current user is in.",
-                          "pattern": "^[^\n\r]*$"
+                          "pattern": "^(.*)$"
                       },
                       "groups": {
                           "$id": "#/properties/allocation/properties/group/items/properties/groups",
@@ -277,7 +277,7 @@
                           "type": "string",
                           "title": "Percentile Allocation Variant",
                           "description": "The name of the variant to use if the calculated percentile for the current user falls in the provided range.",
-                          "pattern": "^[^\n\r]*$"
+                          "pattern": "^(.*)$"
                       },
                       "from": {
                           "$id": "#/properties/allocation/properties/percentile/items/properties/from",


### PR DESCRIPTION
## Why this PR?

Feature management libraries of all languages have feature evaluation event for telemetry. The implementation could be different but there are some reserved properties/fields. This schema specifies the default fields which will be included to a feature evaluation event.

Once this PR is merged, our [doc](https://learn.microsoft.com/en-us/azure/azure-app-configuration/feature-management-dotnet-reference?pivots=preview-version#custom-telemetry-publishing) will reference it.