### PR TITLE
Variant Assignment Tests

### DIFF
--- a/Samples/VariantAssignment.sample.json
+++ b/Samples/VariantAssignment.sample.json
@@ -1,0 +1,155 @@
+{
+    "feature_management": {
+        "feature_flags": [         
+            {
+                "id": "UserAssignedVariant",
+                "description": "",
+                "enabled": "true",
+                "allocation": {
+                    "user": [
+                        {
+                            "variant": "Alpha",
+                            "users": [
+                                "Adam"
+                            ]
+                        },
+                        {
+                            "variant": "Beta",
+                            "users": [
+                                "Britney"
+                            ]
+                        }
+                    ]
+                },
+                "variants": [
+                    {
+                        "name": "Alpha",
+                        "configuration_value": "The Variant Alpha."
+                    },
+                    {
+                        "name": "Beta",
+                        "configuration_value": "The Variant Beta."
+                    }
+                ]
+        
+            },
+            {
+                "id": "GroupAssignedVariant",
+                "description": "",
+                "enabled": "true",
+                "allocation": {
+                    "group": [
+                        {
+                            "variant": "Alpha",
+                            "groups": [
+                                "Ring1"
+                            ]
+                        },
+                        {
+                            "variant": "Beta",
+                            "groups": [
+                                "Ring2"
+                            ]
+                        }
+                    ]
+                },
+                "variants": [
+                    {
+                        "name": "Alpha",
+                        "configuration_value": "The Variant Alpha."
+                    },
+                    {
+                        "name": "Beta",
+                        "configuration_value": "The Variant Beta."
+                    }
+                ]
+            },
+            {
+                "id": "AllocationAssignedVariant",
+                "description": "",
+                "enabled": "true",
+                "allocation": {
+                    "percentile": [
+                        {
+                            "variant": "Alpha",
+                            "from": 0,
+                            "to": 50
+                        },
+                        {
+                            "variant": "Beta",
+                            "from": 50,
+                            "to": 100
+                        }
+                    ]
+                },
+                "variants": [
+                    {
+                        "name": "Alpha",
+                        "configuration_value": "The Variant Alpha."
+                    },
+                    {
+                        "name": "Beta",
+                        "configuration_value": "The Variant Beta."
+                    }
+                ]
+            },
+            {
+                "id": "ComplexAssignment",
+                "description": "",
+                "enabled": "true",
+                "allocation": {
+                    "user": [
+                        {
+                            "variant": "Alpha",
+                            "users": [
+                                "Adam"
+                            ]
+                        },
+                        {
+                            "variant": "Beta",
+                            "users": [
+                                "Britney"
+                            ]
+                        }
+                    ],
+                    "group": [
+                        {
+                            "variant": "Alpha",
+                            "groups": [
+                                "Ring1"
+                            ]
+                        },
+                        {
+                            "variant": "Beta",
+                            "groups": [
+                                "Ring2"
+                            ]
+                        }
+                    ],
+                    "percentile": [
+                        {
+                            "variant": "Alpha",
+                            "from": 0,
+                            "to": 50
+                        },
+                        {
+                            "variant": "Beta",
+                            "from": 50,
+                            "to": 100
+                        }
+                    ]
+                },
+                "variants": [
+                    {
+                        "name": "Alpha",
+                        "configuration_value": "The Variant Alpha."
+                    },
+                    {
+                        "name": "Beta",
+                        "configuration_value": "The Variant Beta."
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/Samples/VariantAssignment.tests.json
+++ b/Samples/VariantAssignment.tests.json
@@ -1,0 +1,150 @@
+[
+    {
+        "FeatureFlagName": "UserAssignedVariant",
+        "Inputs": {
+            "user": "Britney"
+        },
+        "IsEnabled": {
+            "Result": "true"
+        },
+        "Variant": {
+            "Result": "The Variant Beta."
+        },
+        "Description": "A Feature Flag with two Variants, one for Adam and one for Britney."
+    },
+    {
+        "FeatureFlagName": "UserAssignedVariant",
+        "Inputs": {
+            "user": "Adam"
+        },
+        "IsEnabled": {
+            "Result": "true"
+        },
+        "Variant": {
+            "Result": "The Variant Alpha."
+        },
+        "Description": "A Feature Flag with two Variants, one for Adam and one for Britney."
+    },
+    {
+        "FeatureFlagName": "GroupAssignedVariant",
+        "Inputs": {
+            "user": "Britney",
+            "groups": ["Ring2"]
+        },
+        "IsEnabled": {
+            "Result": "true"
+        },
+        "Variant": {
+            "Result": "The Variant Beta."
+        },
+        "Description": "A Feature Flag with two Variants, one for Ring1 and one for Ring2."
+    },
+    {
+        "FeatureFlagName": "GroupAssignedVariant",
+        "Inputs": {
+            "user": "Britney",
+            "groups": ["Ring1"]
+        },
+        "IsEnabled": {
+            "Result": "true"
+        },
+        "Variant": {
+            "Result": "The Variant Alpha."
+        },
+        "Description": "A Feature Flag with two Variants, one for Ring1 and one for Ring2."
+    },
+    {
+        "FeatureFlagName": "AllocationAssignedVariant",
+        "Inputs": {
+            "user": "Britney"
+        },
+        "IsEnabled": {
+            "Result": "true"
+        },
+        "Variant": {
+            "Result": "The Variant Beta."
+        },
+        "Description": "A Feature Flag with two Variants, each with 50%."
+    },
+    {
+        "FeatureFlagName": "AllocationAssignedVariant",
+        "Inputs": {
+            "user": "Adam"
+        },
+        "IsEnabled": {
+            "Result": "true"
+        },
+        "Variant": {
+            "Result": "The Variant Alpha."
+        },
+        "Description": "A Feature Flag with two Variants, each with 50%."
+    },
+    {
+        "FeatureFlagName": "ComplexAssignment",
+        "Inputs": {
+            "user": "Adam"
+        },
+        "IsEnabled": {
+            "Result": "true"
+        },
+        "Variant": {
+            "Result": "The Variant Alpha."
+        },
+        "Description": "A Feature Flag with two Variants, with user, group, and percientile assignment."
+    },
+    {
+        "FeatureFlagName": "ComplexAssignment",
+        "Inputs": {
+            "user": "Britney"
+        },
+        "IsEnabled": {
+            "Result": "true"
+        },
+        "Variant": {
+            "Result": "The Variant Beta."
+        },
+        "Description": "A Feature Flag with two Variants, with user, group, and percientile assignment."
+    },
+    {
+        "FeatureFlagName": "ComplexAssignment",
+        "Inputs": {
+            "user": "John",
+            "groups": ["Ring1"]
+        },
+        "IsEnabled": {
+            "Result": "true"
+        },
+        "Variant": {
+            "Result": "The Variant Alpha."
+        },
+        "Description": "A Feature Flag with two Variants, with user, group, and percientile assignment."
+    },
+    {
+        "FeatureFlagName": "ComplexAssignment",
+        "Inputs": {
+            "user": "Jane",
+            "groups": ["Ring3"]
+        },
+        "IsEnabled": {
+            "Result": "true"
+        },
+        "Variant": {
+            "Result": "The Variant Alpha."
+        },
+        "Description": "A Feature Flag with two Variants, with user, group, and percientile assignment."
+    },
+    {
+        "FeatureFlagName": "ComplexAssignment",
+        "Inputs": {
+            "user": "Selena",
+            "groups": ["Ring4"]
+        },
+        "IsEnabled": {
+            "Result": "true"
+        },
+        "Variant": {
+            "Result": "The Variant Beta."
+        },
+        "Description": "A Feature Flag with two Variants, with user, group, and percientile assignment."
+    }
+]

--- a/libraryValidations/Python/test_json_validations.py
+++ b/libraryValidations/Python/test_json_validations.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-
+import logging
 import json
 import unittest
 from pytest import raises
@@ -22,6 +22,9 @@ USER_KEY = "user"
 GROUPS_KEY = "groups"
 EXCEPTION_KEY = "Exception"
 DESCRIPTION_KEY = "Description"
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def convert_boolean_value(enabled):
@@ -65,6 +68,11 @@ class TestNoFiltersFromFile(unittest.TestCase):
     # method: is_enabled
     def test_basic_variant(self):
         test_key = "BasicVariant"
+        self.run_tests(test_key)
+
+    # method: is_enabled
+    def test_variant_assignment(self):
+        test_key = "VariantAssignment"
         self.run_tests(test_key)
 
     @staticmethod
@@ -111,4 +119,7 @@ class TestNoFiltersFromFile(unittest.TestCase):
                 user = feature_flag_test[INPUTS_KEY].get(USER_KEY, None)
                 groups = feature_flag_test[INPUTS_KEY].get(GROUPS_KEY, [])
                 variant = feature_manager.get_variant(feature_flag_test[FEATURE_FLAG_NAME_KEY], TargetingContext(user_id=user, groups=groups))
+                if not variant:
+                    logger.error(f"Variant is None for {feature_flag_id}")
+                    assert False, failed_description
                 assert variant.configuration == get_variant[RESULT_KEY], failed_description


### PR DESCRIPTION
Adds tests that validate a variant with user assignment, group assignment, allocation assignment, and one with all three.

Done as three separate tests as it would have caught a bug in python.