### PR TITLE
Correct FeatureEvaluationEvent schema

### DIFF
--- a/Schema/FeatureEvaluationEvent/FeatureEvaluationEvent.v1.0.0.schema.json
+++ b/Schema/FeatureEvaluationEvent/FeatureEvaluationEvent.v1.0.0.schema.json
@@ -21,9 +21,13 @@
     },
     "Enabled": {
       "$id": "#/properties/Enabled",
-      "type": "boolean",
+      "type": "string",
       "title": "Feature Enabled",
-      "description": "Whether the feature flag is evaluated as enabled."
+      "description": "Whether the feature flag is evaluated as enabled.",
+      "enum": [
+        "True",
+        "False"
+      ]
     },
     "Variant": {
       "$id": "#/properties/Variant",


### PR DESCRIPTION
The expected out should be "True"/"False" 

Centralized testcase: [ref](https://github.com/microsoft/FeatureManagement/blob/main/Samples/BasicTelemetry.tests.json#L18)
.NET implementation: [ref](https://github.com/microsoft/FeatureManagement-Dotnet/blob/main/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/ApplicationInsightsEventPublisher.cs#L54)
Note in C#, calling ToString on a boolean `true` will produce "True"

JS implementation: [ref](https://github.com/microsoft/FeatureManagement-JavaScript/blob/main/src/feature-management/src/telemetry/featureEvaluationEvent.ts#L22)

Python implementation: in python boolean are born `True` and `False`

