### PR TITLE
Use the raw url so VSCode can parse the reference

### DIFF
--- a/Schema/FeatureManagement.v1.0.0.schema.json
+++ b/Schema/FeatureManagement.v1.0.0.schema.json
@@ -14,7 +14,7 @@
             "title": "Feature Management",
             "description": "Declares feature management configuration.",
             "additionalProperties": {
-                "$ref": "https://github.com/microsoft/FeatureManagement/blob/c5fab16dbf1450dce0bbfe7c4207da735ff31916/Schema/FeatureFlag.v1.1.0.schema.json"
+                "$ref": "https://raw.githubusercontent.com/microsoft/FeatureManagement/c5fab16dbf1450dce0bbfe7c4207da735ff31916/Schema/FeatureFlag.v1.1.0.schema.json"
             }
         }
     }

--- a/Schema/FeatureManagement.v2.0.0.schema.json
+++ b/Schema/FeatureManagement.v2.0.0.schema.json
@@ -23,7 +23,7 @@
                     "title": "Feature Flags",
                     "description": "Declares feature flags based on Microsoft Feature Flag schema.",
                     "items": {
-                        "$ref": "https://github.com/microsoft/FeatureManagement/blob/c5fab16dbf1450dce0bbfe7c4207da735ff31916/Schema/FeatureFlag.v2.0.0.schema.json"
+                        "$ref": "https://raw.githubusercontent.com/microsoft/FeatureManagement/c5fab16dbf1450dce0bbfe7c4207da735ff31916/Schema/FeatureFlag.v2.0.0.schema.json"
                     }
                 }
             }


### PR DESCRIPTION
VScode cannot parse the referenced schema because it points to an HTML page.  By using the raw url we can get the JSON instead.